### PR TITLE
remove extra quote and make site build

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -50,7 +50,6 @@ with open ('info.yml','r') as f:
 
 html_theme_options = {
   "github_url": "https://github.com/CarlosleonR/",
-  ",
   "search_bar_text": "Search this site...",
   "navbar_end": ["search-field.html"],
   "left_sidebar_end":[ "icon-links.html"]


### PR DESCRIPTION
when you deleted the twitter line you missed one character, so sphinx thought you were trying to make another string, but didn't close it and so sphinx got confused.  Removing this should make your site build again. 